### PR TITLE
Updated pre-commit git hook.

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -11,7 +11,9 @@ untracked_files=$(git ls-files --others --exclude-standard site)
 unstaged_changes=$(git diff --name-only site)
 
 if [ -n "$untracked_files" ] || [ -n "$unstaged_changes" ]; then
-    echo -e "\033[1;31mDetected changes in the /site directory:\033[0m"
+    echo -e "\033[1;31mDetected changes in the ./site directory:\033[0m"
+    echo -e "\033[1;33mNote: ./site is tracked by git because it is served by our build process.\033[0m"
+    echo -e "\033[1;33mEnsure all necessary changes, including those in ./site, are staged before committing.\033[0m"
 
     if [ -n "$untracked_files" ]; then
         echo -e "\033[1;33mUntracked files:\033[0m"
@@ -23,15 +25,11 @@ if [ -n "$untracked_files" ] || [ -n "$unstaged_changes" ]; then
         echo "$unstaged_changes"
     fi
 
-    echo "test place 1"
-
     # Prompt the user to continue with the commit
     read -r -p "Do you still want to commit? [y/N] " response < /dev/tty
 
     # Trim leading/trailing whitespace and convert to lowercase
     response=$(echo "$response" | xargs | tr '[:upper:]' '[:lower:]')
-
-    echo "test place 2"
 
     # Check if the response is exactly 'y' or 'yes'
     if [[ "$response" == "y" || "$response" == "yes" ]]; then

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ poetry install # installs the dependencies
 cp .githooks/* .git/hooks/ # installs the git hooks
 ```
 
+This command will have to be repeated by all contributors to the repo every time the git hooks are updated.
+
 ## Using MkDocs in the Virtual Environment
 
 Poetry automatically creates a virtual environment for your project.


### PR DESCRIPTION
This commit updates the `pre-commit` git hook to:

1. Remove extraneous references to a `test place 1` and a `test place 2`.
2. Improved TUI copy explaining why `./site` is tracked by git and any changes to `/.site` should be included in a commit:

    <img width="703" alt="Screenshot 2024-12-31 at 11 19 48" src="https://github.com/user-attachments/assets/7bf9f546-15de-47bc-9d14-5a87d32463e8" />

Important notices:

1. Since git hooks are not tracked by git, all contributors to RCTab Docs will need to re-install the git hooks locally on their repos by running:
    ```shell
    cp .githooks/* .git/hooks
    ```
2. Once this PR is merged in to main, I recommend pulling this change into all of the release branches on GitHub:

    - [ ] releases/1.3.2/doc2.0
    - [ ] releases/1.999/doc0.1

Testing Instructions:

- [ ] checkout this branch
- [ ] run `cp .githooks/* .git/hooks` (this is necessary because git hooks are not tracked by git)
- [ ] Make a change to a markdown file in the `docs` directory
- [ ] Attempt to commit that change (i.e. `git commit)
- [ ] Visualize something similar to the screenshot above
- [ ] Assuming that you have no local changes you need to keep, run `git restore docs site`