### PR TITLE
Pin pygments to fix readthedocs build failure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ mkdocs==1.6.0
 markdown==3.6
 beautifulsoup4==4.12.3
 mkdocs-with-pdf==0.9.3
+pygments<2.20.0


### PR DESCRIPTION
Pygments 2.20.0 has a regression (pygments/pygments#3076) where HtmlFormatter passes None instead of an empty string for a code block's filename option, crashing html.escape() during mkdocs-with-pdf's combined print-page.md render. Pin pygments<2.20.0 until it is patched upstream.